### PR TITLE
feat: ロールから学年ごとにtimesを作成する

### DIFF
--- a/modules/times-manager/constants.ts
+++ b/modules/times-manager/constants.ts
@@ -11,7 +11,3 @@ export const SUB_COMMANDS = {
 };
 
 export const ALUMNUS_ROLE = "卒業生";
-
-export enum ChannelType {
-  GuildCategory = 4,
-}

--- a/modules/times-manager/constants.ts
+++ b/modules/times-manager/constants.ts
@@ -12,4 +12,6 @@ export const SUB_COMMANDS = {
 
 export const ALUMNUS_ROLE = "卒業生";
 
-export const CHANNEL_TYPE_GUILD_CATEGORY = 4;
+export enum ChannelType {
+  GuildCategory = 4,
+}

--- a/modules/times-manager/constants.ts
+++ b/modules/times-manager/constants.ts
@@ -10,4 +10,4 @@ export const SUB_COMMANDS = {
   [SUB_COMMAND_INFO]: "Times Managerの情報を表示する",
 };
 
-export const TIMES_CHANNEL_ID = "1101874714563059742";
+export const ALUMNUS_ROLE = "卒業生";

--- a/modules/times-manager/constants.ts
+++ b/modules/times-manager/constants.ts
@@ -11,3 +11,5 @@ export const SUB_COMMANDS = {
 };
 
 export const ALUMNUS_ROLE = "卒業生";
+
+export const CHANNEL_TYPE_GUILD_CATEGORY = 4;

--- a/modules/times-manager/times-manager.ts
+++ b/modules/times-manager/times-manager.ts
@@ -126,7 +126,7 @@ export class TimesManager extends DiscordBotModule {
         );
         if (!member) {
           await mInteraction.editReply({
-            content: "ユーザーが見つかりませんでした。",
+            content: "ユーザーが見つかりませんでした。運営に問い合わせください。",
           });
           return;
         }
@@ -140,7 +140,7 @@ export class TimesManager extends DiscordBotModule {
           .map((role) => role.name);
         if (roles.length === 0) {
           await mInteraction.editReply({
-            content: "学年ロールが見つかりませんでした。",
+            content: "学年ロールが見つかりませんでした。運営に問い合わせください。",
           });
           return;
         }
@@ -158,7 +158,7 @@ export class TimesManager extends DiscordBotModule {
             content:
               "カテゴリー名「" +
               categoryName +
-              "」が見つかりませんでした。カテゴリーを作成する必要があります。",
+              "」が見つかりませんでした。カテゴリーを作成する必要があります。運営に問い合わせください。",
           });
           return;
         }

--- a/modules/times-manager/times-manager.ts
+++ b/modules/times-manager/times-manager.ts
@@ -18,8 +18,9 @@ import {
   SUB_COMMAND_INFO,
   SUB_COMMAND_CREATE,
   ALUMNUS_ROLE,
-  ChannelType,
 } from "./constants";
+
+import { ChannelType } from "discord-api-types/v10";
 
 export class TimesManager extends DiscordBotModule {
   name = "Times Manager";

--- a/modules/times-manager/times-manager.ts
+++ b/modules/times-manager/times-manager.ts
@@ -18,6 +18,7 @@ import {
   SUB_COMMAND_INFO,
   SUB_COMMAND_CREATE,
   ALUMNUS_ROLE,
+  CHANNEL_TYPE_GUILD_CATEGORY,
 } from "./constants";
 
 export class TimesManager extends DiscordBotModule {
@@ -150,7 +151,7 @@ export class TimesManager extends DiscordBotModule {
         // チャンネルのカテゴリーを取得
         const categoryName = "times-" + roles[0];
         const category = mInteraction.guild?.channels.cache.find(
-          (c) => c.type === 4 && c.name === categoryName
+          (c) => c.type === CHANNEL_TYPE_GUILD_CATEGORY && c.name === categoryName
         );
         if (!category) {
           await mInteraction.editReply({

--- a/modules/times-manager/times-manager.ts
+++ b/modules/times-manager/times-manager.ts
@@ -17,7 +17,7 @@ import {
   SUB_COMMAND_HELP,
   SUB_COMMAND_INFO,
   SUB_COMMAND_CREATE,
-  TIMES_CHANNEL_ID,
+  ALUMNUS_ROLE,
 } from "./constants";
 
 export class TimesManager extends DiscordBotModule {
@@ -119,12 +119,55 @@ export class TimesManager extends DiscordBotModule {
           content: `チャンネル名: \`times-${channelName}\` でチャンネルを作成します`,
         });
 
+        // ロールを取得
+        const member = mInteraction.guild?.members.cache.get(
+          mInteraction.user.id
+        );
+        if (!member) {
+          await mInteraction.editReply({
+            content: "ユーザーが見つかりませんでした。",
+          });
+          return;
+        }
+
+        // ロールをフィルタリングして取得
+        const roles = member.roles.cache
+          .filter((role) => {
+            // 卒業生ロールと学年ロール「xxB」の形式を持つロールを取得
+            return role.name === ALUMNUS_ROLE || role.name.match(/^[0-9]{2}B$/);
+          })
+          .map((role) => role.name);
+        if (roles.length === 0) {
+          await mInteraction.editReply({
+            content: "学年ロールが見つかりませんでした。",
+          });
+          return;
+        }
+
+        // 降順でソートして「卒業生」ロールを優先させる
+        roles.sort().reverse();
+
+        // チャンネルのカテゴリーを取得
+        const categoryName = "times-" + roles[0];
+        const category = mInteraction.guild?.channels.cache.find(
+          (c) => c.type === 4 && c.name === categoryName
+        );
+        if (!category) {
+          await mInteraction.editReply({
+            content:
+              "カテゴリー名「" +
+              categoryName +
+              "」が見つかりませんでした。カテゴリーを作成する必要があります。",
+          });
+          return;
+        }
+
         // チャンネル作成処理
         const guild = mInteraction.guild;
         if (!guild) return;
         const channel = await guild.channels.create({
           name: `times-${channelName}`,
-          parent: TIMES_CHANNEL_ID,
+          parent: category.id,
         });
 
         await mInteraction.editReply({

--- a/modules/times-manager/times-manager.ts
+++ b/modules/times-manager/times-manager.ts
@@ -18,7 +18,7 @@ import {
   SUB_COMMAND_INFO,
   SUB_COMMAND_CREATE,
   ALUMNUS_ROLE,
-  CHANNEL_TYPE_GUILD_CATEGORY,
+  ChannelType,
 } from "./constants";
 
 export class TimesManager extends DiscordBotModule {
@@ -151,7 +151,7 @@ export class TimesManager extends DiscordBotModule {
         // チャンネルのカテゴリーを取得
         const categoryName = "times-" + roles[0];
         const category = mInteraction.guild?.channels.cache.find(
-          (c) => c.type === CHANNEL_TYPE_GUILD_CATEGORY && c.name === categoryName
+          (c) => c.type === ChannelType.GuildCategory && c.name === categoryName
         );
         if (!category) {
           await mInteraction.editReply({


### PR DESCRIPTION
「卒業生」または「23B」などの学年ロールから自動的にカテゴリーを選別してtimesを作成できるようにしました。
該当するカテゴリーが存在しない場合はtimesチャンネルの作成に失敗する(いつかカテゴリー作成も自動化したい)